### PR TITLE
Add darwin-arm64 platform

### DIFF
--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -2,7 +2,7 @@
 set -e
 
 tag=$(git describe --tags --abbrev=0)
-platforms=$(echo "darwin-amd64,linux-386,linux-arm,linux-amd64,linux-arm64,windows-386,windows-amd64" | tr "," "\n")
+platforms=$(echo "darwin-amd64,darwin-arm64,linux-386,linux-arm,linux-amd64,linux-arm64,windows-386,windows-amd64" | tr "," "\n")
 include="dist/*"
 
 if [ -n "${GH_EXT_BUILD_SCRIPT}" ]; then


### PR DESCRIPTION
Hello,

I was trying to install this extension https://github.com/dlvhdr/gh-prs and it's not built for `darwin-arm64`. I've investigated a bit and it led me to open this PR.

I'm not sure if this change is enough, as I'm not familiar with the go ecosystem. I'm available if you need me to test anything :)

Related issue: https://github.com/dlvhdr/gh-prs/issues/10