### PR TITLE
feat: allow for unstable Go versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ By default, Go 1.16 will be used to build your extension. To change this, set `g
     go_version: "1.17"
 ```
 
+To use unstable preview releases of Go, explicitly set the `go_stable` property to `false`:
+
+```yaml
+- uses: cli/gh-extension-precompile@v1
+  with:
+    go_stable: 'false'
+    go_version: "1.18.0-beta1"
+```
+
 ## Using with another language
 
 If you aren't using Go, you'll need to provide your own script for compiling your extension and configure this action to use `build_script_override`:

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,6 @@ inputs:
   go_stable: 
     description: "Whether to download only stable versions"
     default: 'true'
-
-
 branding:
   color: purple
   icon: box

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,11 @@ inputs:
   go_version:
     description: "The Go version to download (if necessary) and use. Supports semver spec and ranges."
     default: '1.16'
+  go_stable: 
+    description: "Whether to download only stable versions"
+    default: 'true'
+
+
 branding:
   color: purple
   icon: box
@@ -19,6 +24,7 @@ runs:
     # out.
     - uses: actions/setup-go@v2
       with:
+        stable: ${{ inputs.go_stable }}
         go-version: ${{ inputs.go_version }}
     - run: ${{ github.action_path }}/build_and_release.sh
       env:


### PR DESCRIPTION
As discussed in https://github.com/cli/gh-extension-precompile/issues/11 this PR adds the option to allow for unstable versions of Go.

This is basically a pass-through of the `stable` property to https://github.com/actions/setup-go.

- feat: allow to use unstable go versions
- doc: explain how to use unstable Go versions
