### PR TITLE
Build smaller binaries

### DIFF
--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -16,7 +16,7 @@ else
     if [[ "${goos}" == "windows" ]]; then
       ext=".exe"
     fi
-    GOOS=${goos} GOARCH=${goarch} go build -o "dist/${goos}-${goarch}${ext}"
+    GOOS=${goos} GOARCH=${goarch} go build -trimpath -ldflags="-s -w" -o "dist/${goos}-${goarch}${ext}"
   done
 fi
 


### PR DESCRIPTION
Adds `-trimpath -ldflags="-s -w"` to the `go build` command to produce smaller binaries with debug symbols removed as well as using `-trimpath` which removes all file system paths from the compiled executable, to improve build reproducibility.