### PR TITLE
feat: Android support

### DIFF
--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -2,7 +2,7 @@
 set -e
 
 tag=$(git describe --tags --abbrev=0)
-platforms=$(echo "darwin-amd64,darwin-arm64,linux-386,linux-arm,linux-amd64,linux-arm64,windows-386,windows-amd64" | tr "," "\n")
+platforms=$(echo "android-amd64,android-arm64,darwin-amd64,darwin-arm64,linux-386,linux-arm,linux-amd64,linux-arm64,windows-386,windows-amd64" | tr "," "\n")
 include="dist/*"
 
 if [ -n "${GH_EXT_BUILD_SCRIPT}" ]; then


### PR DESCRIPTION
The `gh` cli is packaged in the oficial Termux repos so it would make sense to support this platlorm and create binaries for it.

Relates to: https://github.com/dlvhdr/gh-dash/pull/137#issuecomment-1144778803