### PR TITLE
💅 Script refresh

### DIFF
--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -1,42 +1,59 @@
 #!/bin/bash
 set -e
 
-tag=$(git describe --tags --abbrev=0)
-platforms=$(echo "darwin-amd64,darwin-arm64,linux-386,linux-arm,linux-amd64,linux-arm64,windows-386,windows-amd64" | tr "," "\n")
-include="dist/*"
+platforms=(
+  darwin-amd64
+  darwin-arm64
+  linux-386
+  linux-arm
+  linux-amd64
+  linux-arm64
+  windows-386
+  windows-amd64
+)
 
-if [ -n "${GH_EXT_BUILD_SCRIPT}" ]; then
-  echo "invoking build script override ${GH_EXT_BUILD_SCRIPT}"
-  ./${GH_EXT_BUILD_SCRIPT} $tag || exit $?
+if [[ $GITHUB_REF = refs/tags/* ]]; then
+  tag="${GITHUB_REF#refs/tags/}"
 else
-  for p in $platforms; do
-    goos=$(echo $p | sed 's/-.*//')
-    goarch=$(echo $p | sed 's/.*-//')
-    ext=""
-    if [[ "${goos}" == "windows" ]]; then
-      ext=".exe"
-    fi
-    GOOS=${goos} GOARCH=${goarch} go build -trimpath -ldflags="-s -w" -o "dist/${goos}-${goarch}${ext}"
-  done
-fi
-
-ls -A dist >/dev/null || (echo "no files found in dist/" && exit 1)
-
-if [ -n "${GPG_FINGERPRINT}" ]; then
-  for f in $(ls dist); do
-    shasum -a 256 dist/$f >> checksums.txt
-  done
-  gpg --output checksums.txt.sig --detach-sign checksums.txt
-  include="dist/* checksums*"
+  tag="$(git describe --tags --abbrev=0)"
 fi
 
 prerelease=""
-
-if [[ "${tag}" =~ .*-.* ]]; then
-  prerelease="-p"
+if [[ $tag = *-* ]]; then
+  prerelease="--prerelease"
 fi
 
-gh api repos/$GITHUB_REPOSITORY/releases/generate-notes \
-  -f tag_name="${tag}" -q .body > CHANGELOG.md
+if [ -n "$GH_EXT_BUILD_SCRIPT" ]; then
+  echo "invoking build script override $GH_EXT_BUILD_SCRIPT"
+  ./"$GH_EXT_BUILD_SCRIPT" "$tag"
+else
+  for p in "${platforms[@]}"; do
+    goos="${p%-*}"
+    goarch="${p#*-}"
+    ext=""
+    if [ "$goos" = "windows" ]; then
+      ext=".exe"
+    fi
+    GOOS="$goos" GOARCH="$goarch" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}"
+  done
+fi
 
-gh release create $tag $prerelease --notes-file CHANGELOG.md $include
+assets=()
+for f in dist/*; do
+  if [ -f "$f" ]; then
+    assets+=("$f")
+  fi
+done
+
+if [ "${#assets[@]}" -eq 0 ]; then
+  echo "error: no files found in dist/*" >&2
+  exit 1
+fi
+
+if [ -n "$GPG_FINGERPRINT" ]; then
+  shasum -a 256 "${assets[@]}" > checksums.txt
+  gpg --output checksums.txt.sig --detach-sign checksums.txt
+  assets+=(checksums.txt checksums.txt.sig)
+fi
+
+gh release create "$tag" $prerelease --generate-notes -- "${assets[@]}"


### PR DESCRIPTION
- Quote variables in case values contain spaces
- Use bash arrays where applicable
- Use new `gh release create --generate-notes` flag
- Simplify generating checksums
- Release only regular files within `dist/*`
- Fix checking whether `dist/*` is empty