### PR TITLE
Fix building with go 1.16

### DIFF
--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -33,9 +33,15 @@ if [ -n "$GH_EXT_BUILD_SCRIPT" ]; then
   echo "invoking build script override $GH_EXT_BUILD_SCRIPT"
   ./"$GH_EXT_BUILD_SCRIPT" "$tag"
 else
+  IFS=$'\n' read -d '' -r -a supported_platforms < <(go tool dist list) || true
+
   for p in "${platforms[@]}"; do
     goos="${p%-*}"
     goarch="${p#*-}"
+    if [[ " ${supported_platforms[*]} " != *" ${goos}/${goarch} "* ]]; then
+      echo "warning: skipping unsupported platform $p" >&2
+      continue
+    fi
     ext=""
     if [ "$goos" = "windows" ]; then
       ext=".exe"


### PR DESCRIPTION
The newly added platform `windows-arm64` isn't available on Go 1.16. In fact, any unsupported "GOOS-GOARCH" pair should be skipped so that we can keep adding platforms in the future without worrying about whether the Go version that an extension author has chosen for their project supports that platform.

Thanks @samcoe for spotting this bug