### PR TITLE
feat: add existing_release option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ When the `release` workflow finishes running, compiled binaries will be uploaded
 
 You can safely test out release automation by creating tags that have a `-` in them; for example: `v2.0.0-rc.1`. Such Releases will be published as _prereleases_ and will not count as a stable release of your extension.
 
+If you have an existing release, you can set `existing_release` input to `"true"` to have the action upload binaries to the tag instead of creating a new one.
+
 ## Extensions written in other compiled languages
 
 If you aren't using Go for your compiled extension, you'll need to provide your own script for compiling your extension:

--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,17 @@
 name: "release extension"
 description: "Generate a release for a precompiled gh extension"
 inputs:
-  gpg_fingerprint:
-    description: "GPG fingerprint to use for signing releases"
   build_script_override:
     description: "Path to custom build script for producing binaries to upload"
+  existing_release:
+    description: "Upload assets to an existing release"
+    required: false
+    default: "false"
   go_version:
     description: "The Go version to use for compiling (supports semver spec and ranges)"
     default: "1.16"
+  gpg_fingerprint:
+    description: "GPG fingerprint to use for signing releases"
 branding:
   color: purple
   icon: box
@@ -19,9 +23,10 @@ runs:
       with:
         go-version: ${{ inputs.go_version }}
     - run: ${{ github.action_path }}/build_and_release.sh
+      shell: bash
       env:
+        EXISTING_RELEASE: ${{ inputs.existing_release }}
+        GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_TOKEN: ${{ github.token }}
-        GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
-      shell: bash

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -63,12 +63,13 @@ if [ "${#assets[@]}" -eq 0 ]; then
 fi
 
 if [ -n "$GPG_FINGERPRINT" ]; then
-  shasum -a 256 "${assets[@]}" > checksums.txt
+  shasum -a 256 "${assets[@]}" >checksums.txt
   gpg --output checksums.txt.sig --detach-sign checksums.txt
   assets+=(checksums.txt checksums.txt.sig)
 fi
 
-if ! gh release create "$tag" $prerelease --title="${GITHUB_REPOSITORY#*/} ${tag#v}" --generate-notes -- "${assets[@]}"; then
-  echo "trying to upload assets to an existing release instead..."
+if [ "$EXISTING_RELEASE" = "true" ]; then
   gh release upload "$tag" --clobber -- "${assets[@]}"
+else
+  gh release create "$tag" $prerelease --title="${GITHUB_REPOSITORY#*/} ${tag#v}" --generate-notes -- "${assets[@]}"
 fi


### PR DESCRIPTION
## Description

With the current logic, if we have release titles different from `"${GITHUB_REPOSITORY#*/} ${tag#v}"`, we create another release. I figured it would be better if the user knew they wanted to either a) create a release or b) upload to an existing release.