### PR TITLE
bug: Prevent draft release creation if release already exists

### DIFF
--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -68,7 +68,10 @@ if [ -n "$GPG_FINGERPRINT" ]; then
   assets+=(checksums.txt checksums.txt.sig)
 fi
 
-if ! gh release create "$tag" $prerelease --title="${GITHUB_REPOSITORY#*/} ${tag#v}" --generate-notes -- "${assets[@]}"; then
-  echo "trying to upload assets to an existing release instead..."
+if gh release view "$tag" >/dev/null; then
+  echo "uploading assets to an existing release..."
   gh release upload "$tag" --clobber -- "${assets[@]}"
+else
+  echo "creating release and uploading assets..."
+  gh release create "$tag" $prerelease --title="${GITHUB_REPOSITORY#*/} ${tag#v}" --generate-notes -- "${assets[@]}"
 fi


### PR DESCRIPTION
Currently, this action attempts to create a new release with assets and falls back to uploading to an existing release. Even if the call to `gh release create` fails, GitHub creates a draft release with assets attached.

<details>
  <summary>Example</summary>

In [gabe565/gh-profile](https://github.com/gabe565/gh-profile), I created release v1.1.0 in the web UI. The action runs and logs the following:

![image](https://user-images.githubusercontent.com/7717888/196491612-24eee3f2-730e-46f8-8d65-6da57a864e35.png)

But a draft release is created:

![image](https://user-images.githubusercontent.com/7717888/196491642-c2dc957c-e8fe-4dfe-9c1a-0dadd37940b9.png)

</details>


This PR modifies this behavior by checking if a release exists first. If it does, `gh release upload` is called. Else, `gh release create` is called.