### PR TITLE
Disable cgo by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ When the `release` workflow finishes running, compiled binaries will be uploaded
 
 You can safely test out release automation by creating tags that have a `-` in them; for example: `v2.0.0-rc.1`. Such Releases will be published as _prereleases_ and will not count as a stable release of your extension.
 
+By default, the action runs with cgo disabled. To override that default, set the `cgo_enabled` parameter to `1`:
+
+```yaml
+      - uses: cli/gh-extension-precompile@v1
+        with:
+          cgo_enabled: 1
+```
+
 ## Extensions written in other compiled languages
 
 If you aren't using Go for your compiled extension, you'll need to provide your own script for compiling your extension:

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ When the `release` workflow finishes running, compiled binaries will be uploaded
 
 You can safely test out release automation by creating tags that have a `-` in them; for example: `v2.0.0-rc.1`. Such Releases will be published as _prereleases_ and will not count as a stable release of your extension.
 
-By default, the action runs with cgo disabled. To override that default, set the `cgo_enabled` parameter to `1`:
+By default, the action runs with cgo disabled. To override that default, set the `CGO_ENABLED` environment variable to `1`:
 
 ```yaml
       - uses: cli/gh-extension-precompile@v1
-        with:
-          cgo_enabled: 1
+        env:
+          CGO_ENABLED: 1
 ```
 
 ## Extensions written in other compiled languages

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ When the `release` workflow finishes running, compiled binaries will be uploaded
 
 You can safely test out release automation by creating tags that have a `-` in them; for example: `v2.0.0-rc.1`. Such Releases will be published as _prereleases_ and will not count as a stable release of your extension.
 
-By default, the action runs with cgo disabled. To override that default, set the `CGO_ENABLED` environment variable to `1`:
+To maximize portability of built products, this action builds Go binaries with [cgo](https://pkg.go.dev/cmd/cgo) disabled. To override that, set the `CGO_ENABLED` environment variable:
 
 ```yaml
-      - uses: cli/gh-extension-precompile@v1
-        env:
-          CGO_ENABLED: 1
+- uses: cli/gh-extension-precompile@v1
+  env:
+    CGO_ENABLED: 1
 ```
 
 ## Extensions written in other compiled languages

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   go_version:
     description: "The Go version to use for compiling (supports semver spec and ranges)"
     default: "1.18"
+  cgo_enabled:
+    description: "The value of the CGO_ENABLED environment variable"
+    default: 0
 branding:
   color: purple
   icon: box
@@ -24,4 +27,5 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
+        CGO_ENABLED: ${{ inputs.cgo_enabled }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,6 @@ inputs:
   go_version:
     description: "The Go version to use for compiling (supports semver spec and ranges)"
     default: "1.18"
-  cgo_enabled:
-    description: "The value of the CGO_ENABLED environment variable"
-    default: 0
 branding:
   color: purple
   icon: box
@@ -27,5 +24,4 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
-        CGO_ENABLED: ${{ inputs.cgo_enabled }}
       shell: bash

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -34,6 +34,7 @@ if [ -n "$GH_EXT_BUILD_SCRIPT" ]; then
   ./"$GH_EXT_BUILD_SCRIPT" "$tag"
 else
   IFS=$'\n' read -d '' -r -a supported_platforms < <(go tool dist list) || true
+  export CGO_ENABLED="${CGO_ENABLED:-0}"
 
   for p in "${platforms[@]}"; do
     goos="${p%-*}"

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -34,7 +34,6 @@ if [ -n "$GH_EXT_BUILD_SCRIPT" ]; then
   ./"$GH_EXT_BUILD_SCRIPT" "$tag"
 else
   IFS=$'\n' read -d '' -r -a supported_platforms < <(go tool dist list) || true
-  export CGO_ENABLED="${CGO_ENABLED:-0}"
 
   for p in "${platforms[@]}"; do
     goos="${p%-*}"
@@ -47,7 +46,7 @@ else
     if [ "$goos" = "windows" ]; then
       ext=".exe"
     fi
-    GOOS="$goos" GOARCH="$goarch" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}"
+    GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="${CGO_ENABLED:-0}" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}"
   done
 fi
 


### PR DESCRIPTION
As discussed in #29, this disables cgo by default. To avoid making it impossible to override &ndash; maybe somebody builds their extension for exactly one architecture and does want to use cgo for it &ndash; it's not hard-coded in the environment, but set as an optional input parameter that defaults to `0`.

Closes #29