### PR TITLE
Update action path to work on windows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.go_version }}
-    - run: ${{ github.action_path }}/build_and_release.sh
+    - run: ${GITHUB_ACTION_PATH//\\//}/build_and_release.sh
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Previously the path to the action script was `${{ github.action_path }}` which uses the native path format. On Windows machines this ends up passing paths with `\` to bash, which bash tries to interpret as escape characters. "c:\a\b" would get interpreted as "c:ab".

Now the path replaces all instances of `\` with `/` to work with bash on Windows. This assumes that `\` would never be used on other github runners.

Solution was copied from https://github.com/actions/runner/issues/1066