### PR TITLE
parallel runners with matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,30 @@ permissions:
 
 jobs:
   release:
+    strategy:
+      matrix:
+        platform:
+          -  android-amd64
+          -  android-arm64
+          -  darwin-amd64
+          -  darwin-arm64
+          -  freebsd-386
+          -  freebsd-amd64
+          -  freebsd-arm64
+          -  linux-386
+          -  linux-amd64
+          -  linux-arm
+          -  linux-arm64
+          -  windows-386
+          -  windows-amd64
+          -  windows-arm64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cli/gh-extension-precompile@v1
+      - uses: cli/gh-extension-precompile@v2
         with:
           go_version: "1.16"
+          platform: ${{ matrix.platform }}
 ```
 
 Then, either push a new git tag like `v1.0.0` to your repository, or create a new Release and have it initialize the associated git tag.
@@ -36,7 +54,7 @@ You can safely test out release automation by creating tags that have a `-` in t
 To maximize portability of built products, this action builds Go binaries with [cgo](https://pkg.go.dev/cmd/cgo) disabled. To override that, set the `CGO_ENABLED` environment variable:
 
 ```yaml
-- uses: cli/gh-extension-precompile@v1
+- uses: cli/gh-extension-precompile@v2
   env:
     CGO_ENABLED: 1
 ```
@@ -46,7 +64,7 @@ To maximize portability of built products, this action builds Go binaries with [
 If you aren't using Go for your compiled extension, you'll need to provide your own script for compiling your extension:
 
 ```yaml
-- uses: cli/gh-extension-precompile@v1
+- uses: cli/gh-extension-precompile@v2
   with:
     build_script_override: "script/build.sh"
 ```
@@ -91,7 +109,7 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
-      - uses: cli/gh-extension-precompile@v1
+      - uses: cli/gh-extension-precompile@v2
         with:
           gpg_fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -24,4 +24,5 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
+        PLATFORM: ${{ inputs.platform }}
       shell: bash

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -1,22 +1,10 @@
 #!/bin/bash
 set -e
 
-platforms=(
-  android-amd64
-  android-arm64
-  darwin-amd64
-  darwin-arm64
-  freebsd-386
-  freebsd-amd64
-  freebsd-arm64
-  linux-386
-  linux-amd64
-  linux-arm
-  linux-arm64
-  windows-386
-  windows-amd64
-  windows-arm64
-)
+if [[ -z $PLATFORM ]]; then
+  echo "error: missing value for PLATFORM" >&2
+  exit 1
+fi
 
 if [[ $GITHUB_REF = refs/tags/* ]]; then
   tag="${GITHUB_REF#refs/tags/}"
@@ -35,19 +23,13 @@ if [ -n "$GH_EXT_BUILD_SCRIPT" ]; then
 else
   IFS=$'\n' read -d '' -r -a supported_platforms < <(go tool dist list) || true
 
-  for p in "${platforms[@]}"; do
-    goos="${p%-*}"
-    goarch="${p#*-}"
-    if [[ " ${supported_platforms[*]} " != *" ${goos}/${goarch} "* ]]; then
-      echo "warning: skipping unsupported platform $p" >&2
-      continue
-    fi
-    ext=""
-    if [ "$goos" = "windows" ]; then
-      ext=".exe"
-    fi
-    GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="${CGO_ENABLED:-0}" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}"
-  done
+  goos="${PLATFORM%-*}"
+  goarch="${PLATFORM#*-}"
+  ext=""
+  if [ "$goos" = "windows" ]; then
+    ext=".exe"
+  fi
+  GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="${CGO_ENABLED:-0}" go build -trimpath -ldflags="-s -w" -o "dist/${PLATFORM}${ext}"
 fi
 
 assets=()


### PR DESCRIPTION
Leveraging [matrix strategies](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#about-matrix-strategies) we can parallelize the build process for each platform. To me these are breaking changes, and deserves a version bump of the Action from `v1` to `v2`.

### To test this approach:
- I created a test [repo](https://github.com/mntlty/gh-test) using `gh extension create` 
- I copied `build_and_release.sh` from this repo into my test one and modified it
- I modified the `release.yml` workflow file to invoke the modified `build_and_release.sh`
- confirmed I was able to install and run version 0.3.0 of the test extension with `gh`
- Applied the relevant changes in this PR

### This approach has a number of benefits:
1. The overall process is faster. In my test repo I measured the time it took with the [current behavior](https://github.com/mntlty/gh-test/actions/runs/4399379989) at 3m 45s to the [changes](https://github.com/mntlty/gh-test/actions/runs/4399408696) at 37s. This is far from scientific but does indicate that there are likely to be substantial improvements in execution time.
2. For a single [workflow run](https://github.com/mntlty/gh-test/actions/runs/4399408696) each matrix value for `platform` creates an individual job , which makes it easier to see the results for each `platform`.
3. In the event of job failures, individual `platform` builds can be retried, rather than all of them.
4. By moving the platforms list out `build_and_release.sh` it is more accessible to users, as they can modify the values in YAML, and more extensible as they can add or remove platforms that they would like to support in their workflow file. 


### Other considerations:
a. I am not very familiar with Actions billing, and it is possible that having more runners each performing less work is more expensive than a single runner which works for longer. 
b. The template files in the cli, for example https://github.com/cli/cli/blob/78ffa73f4442e3ebfb1121dc13931e45a14a96e2/pkg/cmd/extension/ext_tmpls/goBinWorkflow.yml would need to be updated to take advantage of this change.
c. I'm not sure if there's a better way to test custom Actions than the steps I outlined above.
d. I am not a bash expert by any means, the script looks correct to me and works 🤞. 
e. I learned that the list in `go tool dist list` includes platforms that are not in the current platforms list. I don't know if more should be included in the template or if this covers all of the major platforms and is sufficient as is.
f. I don't believe that this breaks any assumptions for users who provide their own `build_and_release.sh` but please sanity check that for me!