### PR TITLE
Add options for token override, draft releases and supplying release tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,14 +6,14 @@ inputs:
   draft_release:
     description: "Create a draft release"
   github_token:
-    description: "GitHub token to use, defaults to github.token if unspecified"
+    description: "GitHub token to use, defaults to `github.token` if unspecified"
   go_version:
     description: "The Go version to use for compiling (supports semver spec and ranges)"
     default: "1.18"
   gpg_fingerprint:
     description: "GPG fingerprint to use for signing releases"
-  release_tag_override:
-    description: "Existing tag that the release should be created from"
+  release_tag:
+    description: "Existing tag that the release should be created from, defaults to `github.ref` if unspecified"
 branding:
   color: purple
   icon: box
@@ -44,6 +44,6 @@ runs:
         GITHUB_TOKEN: ${{ steps.determine_token.outputs.TOKEN }}
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
-        GH_RELEASE_TAG: ${{ inputs.release_tag_override }}
+        GH_RELEASE_TAG: ${{ inputs.release_tag }}
         DRAFT_RELEASE: ${{ inputs.draft_release }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,8 @@ inputs:
     description: "GPG fingerprint to use for signing releases"
   build_script_override:
     description: "Path to custom build script for producing binaries to upload"
+  release_tag_override:
+    description: "Existing tag that the release should be created from"
   go_version:
     description: "The Go version to use for compiling (supports semver spec and ranges)"
     default: "1.18"
@@ -23,5 +25,6 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_TOKEN: ${{ github.token }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
+        GH_RELEASE_TAG: ${{ inputs.release_tag_override }}
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   gpg_fingerprint:
     description: "GPG fingerprint to use for signing releases"
   release_tag:
-    description: "Existing tag that the release should be created from, defaults to `github.ref` if unspecified"
+    description: "Tag that the release should be created from, defaults to `github.ref` if unspecified"
 branding:
   color: purple
   icon: box

--- a/action.yml
+++ b/action.yml
@@ -38,12 +38,27 @@ runs:
         INPUT_TOKEN: ${{ inputs.github_token }}
       shell: bash
 
+    - id: determine_release_tag
+      run: |
+        if [ -n "$INPUT_TAG" ]; then
+          tag="$INPUT_TAG"
+        elif [[ $GITHUB_REF = refs/tags/* ]]; then
+          tag="${GITHUB_REF#refs/tags/}"
+        else
+          tag="$(git describe --tags --abbrev=0)"
+        fi
+
+        echo "TAG=$tag" >> "$GITHUB_OUTPUT"
+      env:
+        INPUT_TAG: ${{ inputs.release_tag }}
+      shell: bash
+
     - run: ${GITHUB_ACTION_PATH//\\//}/build_and_release.sh
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_TOKEN: ${{ steps.determine_token.outputs.TOKEN }}
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
-        GH_RELEASE_TAG: ${{ inputs.release_tag }}
+        GH_RELEASE_TAG: ${{ steps.determine_release_tag.outputs.TAG }}
         DRAFT_RELEASE: ${{ inputs.draft_release }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,8 @@ inputs:
     description: "Path to custom build script for producing binaries to upload"
   draft_release:
     description: "Create a draft release"
+  github_token:
+    description: "GitHub token to use, defaults to github.token if unspecified"
   go_version:
     description: "The Go version to use for compiling (supports semver spec and ranges)"
     default: "1.18"
@@ -23,23 +25,23 @@ runs:
       with:
         go-version: ${{ inputs.go_version }}
 
-    # if GITHUB_TOKEN env var is set, use it
-    - id: choose_token
+    - id: determine_token
       run: |
-        if [ -n "$GITHUB_TOKEN" ]; then
-          token=$GITHUB_TOKEN
+        if [ -n "$INPUT_TOKEN" ]; then
+          token=$INPUT_TOKEN
         else
-          token=$REPO_TOKEN
+          token=$DEFAULT_TOKEN
         fi
         echo "TOKEN=$token" >> "$GITHUB_OUTPUT"
       env:
-        REPO_TOKEN: ${{ github.token }}
+        DEFAULT_TOKEN: ${{ github.token }}
+        INPUT_TOKEN: ${{ inputs.github_token }}
       shell: bash
 
     - run: ${GITHUB_ACTION_PATH//\\//}/build_and_release.sh
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
-        GITHUB_TOKEN: ${{ steps.choose_token.outputs.TOKEN }}
+        GITHUB_TOKEN: ${{ steps.determine_token.outputs.TOKEN }}
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
         GH_RELEASE_TAG: ${{ inputs.release_tag_override }}

--- a/action.yml
+++ b/action.yml
@@ -1,15 +1,15 @@
 name: "release extension"
 description: "Generate a release for a precompiled gh extension"
 inputs:
-  gpg_fingerprint:
-    description: "GPG fingerprint to use for signing releases"
-  go_version:
-    description: "The Go version to use for compiling (supports semver spec and ranges)"
-    default: "1.18"
   build_script_override:
     description: "Path to custom build script for producing binaries to upload"
   draft_release:
     description: "Create a draft release"
+  go_version:
+    description: "The Go version to use for compiling (supports semver spec and ranges)"
+    default: "1.18"
+  gpg_fingerprint:
+    description: "GPG fingerprint to use for signing releases"
   release_tag_override:
     description: "Existing tag that the release should be created from"
 branding:

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,8 @@ inputs:
     default: "1.18"
   build_script_override:
     description: "Path to custom build script for producing binaries to upload"
+  draft_release:
+    description: "Create a draft release"
   release_tag_override:
     description: "Existing tag that the release should be created from"
 branding:
@@ -38,7 +40,8 @@ runs:
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_TOKEN: ${{ steps.choose_token.outputs.TOKEN }}
+        GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
         GH_RELEASE_TAG: ${{ inputs.release_tag_override }}
-        GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
+        DRAFT_RELEASE: ${{ inputs.draft_release }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -3,13 +3,13 @@ description: "Generate a release for a precompiled gh extension"
 inputs:
   gpg_fingerprint:
     description: "GPG fingerprint to use for signing releases"
+  go_version:
+    description: "The Go version to use for compiling (supports semver spec and ranges)"
+    default: "1.18"
   build_script_override:
     description: "Path to custom build script for producing binaries to upload"
   release_tag_override:
     description: "Existing tag that the release should be created from"
-  go_version:
-    description: "The Go version to use for compiling (supports semver spec and ranges)"
-    default: "1.18"
 branding:
   color: purple
   icon: box
@@ -20,10 +20,24 @@ runs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.go_version }}
+
+    # if GITHUB_TOKEN env var is set, use it
+    - id: choose_token
+      run: |
+        if [ -n "$GITHUB_TOKEN" ]; then
+          token=$GITHUB_TOKEN
+        else
+          token=$REPO_TOKEN
+        fi
+        echo "TOKEN=$token" >> "$GITHUB_OUTPUT"
+      env:
+        REPO_TOKEN: ${{ github.token }}
+      shell: bash
+
     - run: ${GITHUB_ACTION_PATH//\\//}/build_and_release.sh
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ steps.choose_token.outputs.TOKEN }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
         GH_RELEASE_TAG: ${{ inputs.release_tag_override }}
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -19,7 +19,6 @@ platforms=(
 )
 
 if [ -n "$GH_RELEASE_TAG" ]; then
-  echo "invoking release tag override $GH_RELEASE_TAG"
   tag="$GH_RELEASE_TAG"
 elif [[ $GITHUB_REF = refs/tags/* ]]; then
   tag="${GITHUB_REF#refs/tags/}"

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -18,16 +18,8 @@ platforms=(
   windows-arm64
 )
 
-if [ -n "$GH_RELEASE_TAG" ]; then
-  tag="$GH_RELEASE_TAG"
-elif [[ $GITHUB_REF = refs/tags/* ]]; then
-  tag="${GITHUB_REF#refs/tags/}"
-else
-  tag="$(git describe --tags --abbrev=0)"
-fi
-
 prerelease=""
-if [[ $tag = *-* ]]; then
+if [[ $GH_RELEASE_TAG = *-* ]]; then
   prerelease="--prerelease"
 fi
 
@@ -38,7 +30,7 @@ fi
 
 if [ -n "$GH_EXT_BUILD_SCRIPT" ]; then
   echo "invoking build script override $GH_EXT_BUILD_SCRIPT"
-  ./"$GH_EXT_BUILD_SCRIPT" "$tag"
+  ./"$GH_EXT_BUILD_SCRIPT" "$GH_RELEASE_TAG"
 else
   IFS=$'\n' read -d '' -r -a supported_platforms < <(go tool dist list) || true
 
@@ -75,10 +67,10 @@ if [ -n "$GPG_FINGERPRINT" ]; then
   assets+=(checksums.txt checksums.txt.sig)
 fi
 
-if gh release view "$tag" >/dev/null; then
+if gh release view "$GH_RELEASE_TAG" >/dev/null; then
   echo "uploading assets to an existing release..."
-  gh release upload "$tag" --clobber -- "${assets[@]}"
+  gh release upload "$GH_RELEASE_TAG" --clobber -- "${assets[@]}"
 else
   echo "creating release and uploading assets..."
-  gh release create "$tag" $prerelease $draft_release --title="${GITHUB_REPOSITORY#*/} ${tag#v}" --generate-notes -- "${assets[@]}"
+  gh release create "$GH_RELEASE_TAG" $prerelease $draft_release --title="${GITHUB_REPOSITORY#*/} ${GH_RELEASE_TAG#v}" --generate-notes -- "${assets[@]}"
 fi

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -18,7 +18,10 @@ platforms=(
   windows-arm64
 )
 
-if [[ $GITHUB_REF = refs/tags/* ]]; then
+if [ -n "$GH_RELEASE_TAG" ]; then
+  echo "invoking release tag override $GH_RELEASE_TAG"
+  tag="$GH_RELEASE_TAG"
+elif [[ $GITHUB_REF = refs/tags/* ]]; then
   tag="${GITHUB_REF#refs/tags/}"
 else
   tag="$(git describe --tags --abbrev=0)"

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -32,6 +32,11 @@ if [[ $tag = *-* ]]; then
   prerelease="--prerelease"
 fi
 
+draft_release=""
+if [[ "$DRAFT_RELEASE" = "true" ]]; then
+  draft_release="--draft"
+fi
+
 if [ -n "$GH_EXT_BUILD_SCRIPT" ]; then
   echo "invoking build script override $GH_EXT_BUILD_SCRIPT"
   ./"$GH_EXT_BUILD_SCRIPT" "$tag"
@@ -76,5 +81,5 @@ if gh release view "$tag" >/dev/null; then
   gh release upload "$tag" --clobber -- "${assets[@]}"
 else
   echo "creating release and uploading assets..."
-  gh release create "$tag" $prerelease --title="${GITHUB_REPOSITORY#*/} ${tag#v}" --generate-notes -- "${assets[@]}"
+  gh release create "$tag" $prerelease $draft_release --title="${GITHUB_REPOSITORY#*/} ${tag#v}" --generate-notes -- "${assets[@]}"
 fi


### PR DESCRIPTION
As part of the release of an upcoming CLI extension in which the built binary gets uploaded to a secondary repository instead of the one in which the code resides the following options were added:

- allow creating a `draft` release
- allow supplying a `github_token` input parameter in order to allow using a token other than `github.token`
- allow supplying a pre-created release tag