### PR TITLE
Adding essential codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cli/code-reviewers


### PR DESCRIPTION
Closes #38

This is a simple version of the `cli/cli` codeowners file.  Separately, I will review the repository settings to see about the missing repository ruleset for leveraging this. 