### PR TITLE
Add input variable to allow overriding release title

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,9 +30,9 @@ runs:
     - id: determine_token
       run: |
         if [ -n "$INPUT_TOKEN" ]; then
-          token=$INPUT_TOKEN
+          token="$INPUT_TOKEN"
         else
-          token=$DEFAULT_TOKEN
+          token="$DEFAULT_TOKEN"
         fi
         echo "TOKEN=$token" >> "$GITHUB_OUTPUT"
       env:
@@ -58,7 +58,7 @@ runs:
     - id: determine_release_title
       run: |
         if [ -n "$INPUT_TITLE" ]; then
-          title=$INPUT_TITLE
+          title="$INPUT_TITLE"
         else
           title="${GITHUB_REPOSITORY#*/}"
         fi

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,8 @@ inputs:
     description: "GPG fingerprint to use for signing releases"
   release_tag:
     description: "Tag that the release should be created from, defaults to `github.ref` if unspecified"
+  release_title:
+    description: "Title of the release, defaults to repository name if unspecified"
 branding:
   color: purple
   icon: box
@@ -53,6 +55,18 @@ runs:
         INPUT_TAG: ${{ inputs.release_tag }}
       shell: bash
 
+    - id: determine_release_title
+      run: |
+        if [ -n "$INPUT_TITLE" ]; then
+          title=$INPUT_TITLE
+        else
+          title="${GITHUB_REPOSITORY#*/}"
+        fi
+        echo "TITLE=$title" >> "$GITHUB_OUTPUT"
+      env:
+        INPUT_TITLE: ${{ inputs.release_title }}
+      shell: bash
+
     - run: ${GITHUB_ACTION_PATH//\\//}/build_and_release.sh
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
@@ -60,5 +74,6 @@ runs:
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
         GH_RELEASE_TAG: ${{ steps.determine_release_tag.outputs.TAG }}
+        GH_RELEASE_TITLE: ${{ steps.determine_release_title.outputs.TITLE }}
         DRAFT_RELEASE: ${{ inputs.draft_release }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,8 @@ inputs:
     description: "GPG fingerprint to use for signing releases"
   release_tag:
     description: "Tag that the release should be created from, defaults to `github.ref` if unspecified"
-  release_title:
-    description: "Title of the release, defaults to repository name if unspecified"
+  release_title_prefix:
+    description: "Title prefix of the release, defaults to repository name if unspecified"
 branding:
   color: purple
   icon: box
@@ -55,16 +55,16 @@ runs:
         INPUT_TAG: ${{ inputs.release_tag }}
       shell: bash
 
-    - id: determine_release_title
+    - id: determine_release_title_prefix
       run: |
         if [ -n "$INPUT_TITLE" ]; then
-          title="$INPUT_TITLE"
+          prefix="$INPUT_TITLE"
         else
-          title="${GITHUB_REPOSITORY#*/}"
+          prefix="${GITHUB_REPOSITORY#*/}"
         fi
-        echo "TITLE=$title" >> "$GITHUB_OUTPUT"
+        echo "PREFIX=$prefix" >> "$GITHUB_OUTPUT"
       env:
-        INPUT_TITLE: ${{ inputs.release_title }}
+        INPUT_TITLE: ${{ inputs.release_title_prefix }}
       shell: bash
 
     - run: ${GITHUB_ACTION_PATH//\\//}/build_and_release.sh
@@ -74,6 +74,6 @@ runs:
         GPG_FINGERPRINT: ${{ inputs.gpg_fingerprint }}
         GH_EXT_BUILD_SCRIPT: ${{ inputs.build_script_override }}
         GH_RELEASE_TAG: ${{ steps.determine_release_tag.outputs.TAG }}
-        GH_RELEASE_TITLE: ${{ steps.determine_release_title.outputs.TITLE }}
+        GH_RELEASE_TITLE_PREFIX: ${{ steps.determine_release_title_prefix.outputs.PREFIX }}
         DRAFT_RELEASE: ${{ inputs.draft_release }}
       shell: bash

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -72,5 +72,5 @@ if gh release view "$GH_RELEASE_TAG" >/dev/null; then
   gh release upload "$GH_RELEASE_TAG" --clobber -- "${assets[@]}"
 else
   echo "creating release and uploading assets..."
-  gh release create "$GH_RELEASE_TAG" $prerelease $draft_release --title="${GITHUB_REPOSITORY#*/} ${GH_RELEASE_TAG#v}" --generate-notes -- "${assets[@]}"
+  gh release create "$GH_RELEASE_TAG" $prerelease $draft_release --title="${GH_RELEASE_TITLE} ${GH_RELEASE_TAG#v}" --generate-notes -- "${assets[@]}"
 fi

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -72,5 +72,5 @@ if gh release view "$GH_RELEASE_TAG" >/dev/null; then
   gh release upload "$GH_RELEASE_TAG" --clobber -- "${assets[@]}"
 else
   echo "creating release and uploading assets..."
-  gh release create "$GH_RELEASE_TAG" $prerelease $draft_release --title="${GH_RELEASE_TITLE} ${GH_RELEASE_TAG#v}" --generate-notes -- "${assets[@]}"
+  gh release create "$GH_RELEASE_TAG" $prerelease $draft_release --title="${GH_RELEASE_TITLE_PREFIX} ${GH_RELEASE_TAG#v}" --generate-notes -- "${assets[@]}"
 fi


### PR DESCRIPTION
In order to be able to provide a custom release title instead of the repository name, this PR introduces a `release_title` input variable.