### PR TITLE
Add go.mod support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,8 @@ inputs:
     description: "GitHub token to use, defaults to `github.token` if unspecified"
   go_version:
     description: "The Go version to use for compiling (supports semver spec and ranges)"
-    default: "1.18"
+  go_version_file:
+    description: Path to the go.mod or go.work file to determine version of go to use
   gpg_fingerprint:
     description: "GPG fingerprint to use for signing releases"
   release_tag:
@@ -25,7 +26,13 @@ runs:
     # TODO: figure out how to avoid setting up Go for non-Go extensions
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ inputs.go_version }}
+        # The default go version is managed here because actions/setup-go favors go-version over go-version-file,
+        # requiring us to only pass it if no other inputs are provided.
+        #
+        # Otherwise, we pass along the values given, letting the user catch the warning notice in the logs
+        # and picking either go-version or go-version-file.
+        go-version: ${{(inputs.go_version_file == '' && inputs.go_version == '') && '1.18' || inputs.go_version}}
+        go-version-file: ${{inputs.go_version_file}}
 
     - id: determine_token
       run: |


### PR DESCRIPTION
Fixes #46 

These changes add `go_version_file` input to define path to `go.mod` or `go.work` file containing the Go version to use.

## Testing

**[`go.mod`](https://github.com/tinyfists/gh-nonsense-internal/blob/main/go.mod)**

```
module github.com/tinyfists/gh-nonsense

go 1.20
```

### Original using default input value

- [Workflow](https://github.com/tinyfists/gh-nonsense-internal/actions/runs/6656797229/workflow)

  ```yaml
      steps:
        - uses: actions/checkout@v3
        - uses: cli/gh-extension-precompile@v1
  ```

- [Workflow run](https://github.com/tinyfists/gh-nonsense-internal/actions/runs/6656797229/job/18090145770#step:3:12)

  ```
  Setup go version spec 1.18
  Attempting to download 1.18...
  matching 1.18...
  Acquiring 1.18.10 from https://github.com/actions/go-versions/releases/download/1.18.10-3890634278/go-1.18.10-linux-x64.tar.gz
  Extracting Go...
  ```

### New using `go.mod` input value

- [Workflow](https://github.com/tinyfists/gh-nonsense-internal/actions/runs/6659261316/workflow)

  ```yaml
        - uses: cli/gh-extension-precompile@andyfeller/46-go-mod-support
          with:
            go_version_file: go.mod
  ```

- [Workflow run](https://github.com/tinyfists/gh-nonsense-internal/actions/runs/6659261316/job/18097961514#step:3:12)

  ```
  Run actions/setup-go@v3
  Setup go version spec 1.20
  Found in cache @ /opt/hostedtoolcache/go/1.20.10/x64
  Added go to the path
  Successfully set up Go version 1.20
  go version go1.20.10 linux/amd64
  ```

### New using both `go_version` and `go_version_file` with `go_version` of 1.19 being used

- [Workflow](https://github.com/tinyfists/gh-nonsense-internal/actions/runs/6659389467/workflow#L14-L17)

  ```yaml
        - uses: cli/gh-extension-precompile@andyfeller/46-go-mod-support
          with:
            go_version: 1.19
            go_version_file: go.mod
  ```

- [Workflow run](https://github.com/tinyfists/gh-nonsense-internal/actions/runs/6659389467/job/18098346598#step:3:6)

  ```
  Run actions/setup-go@v3
  Warning: Both go-version and go-version-file inputs are specified, only go-version will be used
  Setup go version spec 1.19
  Found in cache @ /opt/hostedtoolcache/go/1.19.[13](https://github.com/tinyfists/gh-nonsense-internal/actions/runs/6659389467/job/18098346598#step:3:15)/x64
  Added go to the path
  Successfully set up Go version 1.19
  go version go1.19.13 linux/amd64
  ```

### New using default input values, resulting in 1.18 being used

- [Workflow](https://github.com/tinyfists/gh-nonsense-internal/actions/runs/6659398809/workflow#L14)

  ```yaml
      steps:
        - uses: actions/checkout@v3
        - uses: cli/gh-extension-precompile@andyfeller/46-go-mod-support
  ```

- [Workflow run](https://github.com/tinyfists/gh-nonsense-internal/actions/runs/6659398809/job/18098374871#step:3:4)

  ```
  Run actions/setup-go@v3
  Setup go version spec 1.18
  Attempting to download 1.18...
  matching 1.18...
  Acquiring 1.18.10 from https://github.com/actions/go-versions/releases/download/1.18.10-38[9](https://github.com/tinyfists/gh-nonsense-internal/actions/runs/6659398809/job/18098374871#step:3:11)0634278/go-1.18.[10](https://github.com/tinyfists/gh-nonsense-internal/actions/runs/6659398809/job/18098374871#step:3:12)-linux-x64.tar.gz
  Extracting Go...
  ```