### PR TITLE
feat: add attestation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,35 @@ jobs:
           gpg_fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}
 ```
 
+
+## Attest
+
+This action can optionally generate signed build provenance attestations for all published executables.
+
+```yaml
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cli/gh-extension-precompile@v1
+        with:
+          attest: true
+```
+
+
 ## Authors
 
 - nate smith <https://github.com/vilmibm>

--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ jobs:
 ```
 
 
-## Attest
+## Support for Artifact Attestations
 
-This action can optionally generate signed build provenance attestations for all published executables.
+This action can optionally generate signed build provenance attestations for all published executables within `${{ github.workspace }}/dist/*`.
+
+For more information, see ["Using artifact attestations to establish provenance for builds"](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
 
 ```yaml
 name: release
@@ -121,7 +123,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cli/gh-extension-precompile@v1
         with:
-          attest: true
+          generate_attestations: true
 ```
 
 

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,8 @@ inputs:
     description: "Tag that the release should be created from, defaults to `github.ref` if unspecified"
   release_title_prefix:
     description: "Title prefix of the release, defaults to repository name if unspecified"
-  attest:
-    description: "Whether to attest the binaries, defaults to `false` if unspecified"
+  generate_attestations:
+    description: "Whether to generate artifact attestations for release binaries to establish build provenance, defaults to `false` if unspecified"
     default: false
 branding:
   color: purple
@@ -88,7 +88,7 @@ runs:
         DRAFT_RELEASE: ${{ inputs.draft_release }}
       shell: bash
 
-    - if: ${{ inputs.attest == 'true' }}
+    - if: ${{ inputs.generate_attestations == 'true' }}
       uses: actions/attest-build-provenance@v1
       with:
         subject-path: '${{ github.workspace }}/dist/*'

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
     description: "Tag that the release should be created from, defaults to `github.ref` if unspecified"
   release_title_prefix:
     description: "Title prefix of the release, defaults to repository name if unspecified"
+  attest:
+    description: "Whether to attest the binaries, defaults to `false` if unspecified"
+    default: false
 branding:
   color: purple
   icon: box
@@ -84,3 +87,8 @@ runs:
         GH_RELEASE_TITLE_PREFIX: ${{ steps.determine_release_title_prefix.outputs.PREFIX }}
         DRAFT_RELEASE: ${{ inputs.draft_release }}
       shell: bash
+
+    - if: ${{ inputs.attest == 'true' }}
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: '${{ github.workspace }}/dist/*'


### PR DESCRIPTION
Support https://github.com/actions/attest-build-provenance for the attestation.


