### PR TITLE
enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+
+  # GitHub actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
### What

Enable dependabot for GitHub actions

### Why

I've just discovered an action dependency a bit [old](https://github.com/cli/gh-extension-precompile/blob/309b2c213e7e8455e3ad7afbae4b0987735b554d/action.yml#L30)

That has been annotated with a warning:

<img width="1583" alt="image" src="https://github.com/cli/gh-extension-precompile/assets/2871786/d64fc50a-ccd8-477d-bb79-5b76133c6e42">

This should help with bumping versions in an automated manner  :)
