### PR TITLE
Update `setup-go` action for latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A GitHub CLI extension is any GitHub repository named `gh-*` that publishes a Re
 
 ## Go extensions
 
+> [!Note]
+> With the use of `actions/setup-go@v5` for Go extensions, **cache is enabled by default** as part of the [action's `v4` release](https://github.com/actions/setup-go/releases/tag/v4.0.0). The action won’t throw an error if the cache can’t be restored or saved. The action will throw a warning message but it won’t stop a build process. 
+
 Create a workflow file at `.github/workflows/release.yml`:
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
   using: composite
   steps:
     # TODO: figure out how to avoid setting up Go for non-Go extensions
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v5
       with:
         # The default go version is managed here because actions/setup-go favors go-version over go-version-file,
         # requiring us to only pass it if no other inputs are provided.


### PR DESCRIPTION
Existing `actions/setup-go@v3` usage is [referring to legacy/deprecated](https://github.com/actions/setup-go/blob/v3/action.yml#L28) `node16` in the actions:

```yml
runs:
  using: 'node16'
  main: 'dist/setup/index.js'
  post: 'dist/cache-save/index.js'
  post-if: success()
```

This PR updates the `setup-go` action to use latest version.

Confirmed stripped down logic is successful in GitHub CLI extension: [`katiem0/gh-collaborators`](https://github.com/katiem0/gh-collaborators/blob/main/.github/workflows/release.yml)

No identified breaking changes are introduced between [v3 and v5](https://github.com/actions/setup-go/compare/v3.5.0...v5.0.1).