### PR TITLE
Fix android builds requiring external (cgo) linking, but cgo is not enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cli/gh-extension-precompile@v2
         with:
-          go_version: "1.16"
+          go_version_file: go.mod
 ```
 
 Then, either push a new git tag like `v1.0.0` to your repository, or create a new Release and have it initialize the associated git tag.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cli/gh-extension-precompile@v1
+      - uses: cli/gh-extension-precompile@v2
         with:
           go_version: "1.16"
 ```
@@ -39,14 +39,14 @@ You can safely test out release automation by creating tags that have a `-` in t
 To maximize portability of built products, this action builds Go binaries with [cgo](https://pkg.go.dev/cmd/cgo) disabled unless you enable building for Android targets. To override cgo for all build targets, set the `CGO_ENABLED` environment variable:
 
 ```yaml
-- uses: cli/gh-extension-precompile@v1
+- uses: cli/gh-extension-precompile@v2
   env:
     CGO_ENABLED: 1
 ```
 
 ### Building for Android
 
-As of `gh-extension-precompile@2`, building for Android targets like `android-arm64` and `android-amd64` is disabled by default. To enable building for Android targets, set at least the `release_android` and `android_sdk_version` action inputs:
+As of `gh-extension-precompile@v2`, building for Android targets like `android-arm64` and `android-amd64` is disabled by default. To enable building for Android targets, set at least the `release_android` and `android_sdk_version` action inputs:
 
 ```yaml
 - uses: cli/gh-extension-precompile@v2
@@ -72,7 +72,7 @@ However, if you are running the workflow on a self-hosted runner, you need to al
 If you aren't using Go for your compiled extension, you'll need to provide your own script for compiling your extension:
 
 ```yaml
-- uses: cli/gh-extension-precompile@v1
+- uses: cli/gh-extension-precompile@v2
   with:
     build_script_override: "script/build.sh"
 ```
@@ -117,7 +117,7 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
-      - uses: cli/gh-extension-precompile@v1
+      - uses: cli/gh-extension-precompile@v2
         with:
           gpg_fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}
 ```
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cli/gh-extension-precompile@v1
+      - uses: cli/gh-extension-precompile@v2
         with:
           generate_attestations: true
 ```

--- a/README.md
+++ b/README.md
@@ -67,9 +67,13 @@ However, if you are running the workflow on a self-hosted runner, you need to al
     android_ndk_home: /path/to/android-ndk
 ```
 
+### Customizing the build process for Go extensions
+
+If you need to customize the build process for your Go extension, you can provide a custom build script. See [Extensions written in other compiled languages](#extensions-written-in-other-compiled-languages) below for instructions.
+
 ## Extensions written in other compiled languages
 
-If you aren't using Go for your compiled extension, you'll need to provide your own script for compiling your extension:
+If you aren't using Go for your compiled extension, or your Go extension requires customizations to the build script, you'll need to provide your own script for compiling your extension:
 
 ```yaml
 - uses: cli/gh-extension-precompile@v2

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ When the `release` workflow finishes running, compiled binaries will be uploaded
 
 You can safely test out release automation by creating tags that have a `-` in them; for example: `v2.0.0-rc.1`. Such Releases will be published as _prereleases_ and will not count as a stable release of your extension.
 
-To maximize portability of built products, this action builds Go binaries with [cgo](https://pkg.go.dev/cmd/cgo) disabled unless you [enable building for Android targets](#building-for-android). To override cgo for all build targets, set the `CGO_ENABLED` environment variable:
+To maximize portability of built products, this action builds Go binaries with [cgo](https://pkg.go.dev/cmd/cgo) disabled with the exception of [Android build targets](#building-for-android). To override cgo for all build targets, set the `CGO_ENABLED` environment variable:
 
 ```yaml
 - uses: cli/gh-extension-precompile@v2
@@ -46,28 +46,17 @@ To maximize portability of built products, this action builds Go binaries with [
 
 ### Building for Android
 
-As of `gh-extension-precompile@v2`, building for Android targets like `android-arm64` and `android-amd64` is disabled by default. To enable building for Android targets, set at least the `release_android` and `android_sdk_version` action inputs:
+`gh-extension-precompile@v2` introduces a breaking change by disabling `android-arm64` and `android-amd64` build targets by default due to [Go external linking requirements](https://github.com/cli/gh-extension-precompile/issues/50#issuecomment-2078086299).
 
-```yaml
-- uses: cli/gh-extension-precompile@v2
-  with:
-    go_version_file: go.mod
-    release_android: true
-    android_sdk_version: 34
-```
+To enable Android build targets:
 
-If you are running the workflow on a GitHub hosted runner, you do not need to set the `android_ndk_home` input. The Android SDK Build-tools and environment variables required to build for Android targets are [pre-installed and configured on GitHub hosted runners](https://github.com/actions/runner-images/blob/8cdc506384655ceaaa62d3f800e15b844e06bea4/images/ubuntu/Ubuntu2404-Readme.md?plain=1#L214-L233). 
+1. `release_android` must be set to `true`
+2. `android_sdk_version` must be set to a targeted [Android API level](https://developer.android.com/tools/releases/platforms)
+3. `android_ndk_home` must be set to the path to Android NDK installed on Actions runner
 
-However, if you are running the workflow on a self-hosted runner, you need to also configure the `android_ndk_home` action input to the installation path of the Android NDK on the runner:
+   `cli/gh-extension-precompile` will use pre-installed Android tools on GitHub-managed runners by default; self-hosted runners will need to install and configure this input.
 
-```yaml
-- uses: cli/gh-extension-precompile@v2
-  with:
-    go_version_file: go.mod
-    release_android: true
-    android_sdk_version: 34
-    android_ndk_home: /path/to/android-ndk
-```
+   _For more information on Android NDK installed on GitHub-managed runners, see [`actions/runner-images`](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#android)
 
 ### Customizing the build process for Go extensions
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To enable Android build targets:
 
    `cli/gh-extension-precompile` will use pre-installed Android tools on GitHub-managed runners by default; self-hosted runners will need to install and configure this input.
 
-   _For more information on Android NDK installed on GitHub-managed runners, see [`actions/runner-images`](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#android)
+   _For more information on Android NDK installed on GitHub-managed runners, see [`actions/runner-images`](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#android)_
 
 ### Customizing the build process for Go extensions
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,35 @@ When the `release` workflow finishes running, compiled binaries will be uploaded
 
 You can safely test out release automation by creating tags that have a `-` in them; for example: `v2.0.0-rc.1`. Such Releases will be published as _prereleases_ and will not count as a stable release of your extension.
 
-To maximize portability of built products, this action builds Go binaries with [cgo](https://pkg.go.dev/cmd/cgo) disabled. To override that, set the `CGO_ENABLED` environment variable:
+To maximize portability of built products, this action builds Go binaries with [cgo](https://pkg.go.dev/cmd/cgo) disabled unless you enable building for Android targets. To override cgo for all build targets, set the `CGO_ENABLED` environment variable:
 
 ```yaml
 - uses: cli/gh-extension-precompile@v1
   env:
     CGO_ENABLED: 1
+```
+
+### Building for Android
+
+As of `gh-extension-precompile@2`, building for Android targets like `android-arm64` and `android-amd64` is disabled by default. To enable building for Android targets, set at least the `release_android` and `android_sdk_version` action inputs:
+
+```yaml
+- uses: cli/gh-extension-precompile@v2
+  with:
+    release_android: true
+    android_sdk_version: 34
+```
+
+If you are running the workflow on a GitHub hosted runner, you do not need to set the `android_ndk_home` input. The Android SDK Build-tools and environment variables required to build for Android targets are [pre-installed and configured on GitHub hosted runners](https://github.com/actions/runner-images/blob/8cdc506384655ceaaa62d3f800e15b844e06bea4/images/ubuntu/Ubuntu2404-Readme.md?plain=1#L214-L233). 
+
+However, if you are running the workflow on a self-hosted runner, you need to also configure the `android_ndk_home` action input to the installation path of the Android NDK on the runner:
+
+```yaml
+- uses: cli/gh-extension-precompile@v2
+  with:
+    release_android: true
+    android_sdk_version: 34
+    android_ndk_home: /path/to/android-ndk
 ```
 
 ## Extensions written in other compiled languages

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ jobs:
           gpg_fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}
 ```
 
-
 ## Support for Artifact Attestations
 
 This action can optionally generate signed build provenance attestations for all published executables within `${{ github.workspace }}/dist/*`.
@@ -157,7 +156,6 @@ jobs:
         with:
           generate_attestations: true
 ```
-
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ When the `release` workflow finishes running, compiled binaries will be uploaded
 
 You can safely test out release automation by creating tags that have a `-` in them; for example: `v2.0.0-rc.1`. Such Releases will be published as _prereleases_ and will not count as a stable release of your extension.
 
-To maximize portability of built products, this action builds Go binaries with [cgo](https://pkg.go.dev/cmd/cgo) disabled unless you enable building for Android targets. To override cgo for all build targets, set the `CGO_ENABLED` environment variable:
+To maximize portability of built products, this action builds Go binaries with [cgo](https://pkg.go.dev/cmd/cgo) disabled unless you [enable building for Android targets](#building-for-android). To override cgo for all build targets, set the `CGO_ENABLED` environment variable:
 
 ```yaml
 - uses: cli/gh-extension-precompile@v2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cli/gh-extension-precompile@v2
         with:
           go_version_file: go.mod
@@ -117,7 +117,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
         with:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ As of `gh-extension-precompile@v2`, building for Android targets like `android-a
 ```yaml
 - uses: cli/gh-extension-precompile@v2
   with:
+    go_version_file: go.mod
     release_android: true
     android_sdk_version: 34
 ```
@@ -62,6 +63,7 @@ However, if you are running the workflow on a self-hosted runner, you need to al
 ```yaml
 - uses: cli/gh-extension-precompile@v2
   with:
+    go_version_file: go.mod
     release_android: true
     android_sdk_version: 34
     android_ndk_home: /path/to/android-ndk

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: "Whether to release android binaries, defaults to `false` if unspecified"
     default: false
   android_ndk_home:
-    description: "Path to the Android NDK for android-amd64 and android-arm64 builds, required for Go 1.22 or newer, defaults to `ANDROID_NDK_HOME` environment variable if unspecified"
+    description: "Path to the Android NDK for android-amd64 and android-arm64 builds"
   android_sdk_version:
     description: "Android SDK build-tools version"
 branding:

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,13 @@ inputs:
   generate_attestations:
     description: "Whether to generate artifact attestations for release binaries to establish build provenance, defaults to `false` if unspecified"
     default: false
+  release_android:
+    description: "Whether to release android binaries, defaults to `false` if unspecified"
+    default: false
+  android_ndk_home:
+    description: "Path to the Android NDK for android-amd64 and android-arm64 builds, required for Go 1.22 or newer, defaults to `ANDROID_NDK_HOME` environment variable if unspecified"
+  android_sdk_version:
+    description: "Android SDK build-tools version"
 branding:
   color: purple
   icon: box
@@ -77,6 +84,18 @@ runs:
         INPUT_TITLE: ${{ inputs.release_title_prefix }}
       shell: bash
 
+    - id: determine_android_ndk_home
+      run: |
+        if [ -n "$INPUT_ANDROID_NDK_HOME" ]; then
+          android_ndk_home="$INPUT_ANDROID_NDK_HOME"
+        else
+          android_ndk_home="$ANDROID_NDK_HOME"
+        fi
+        echo "ANDROID_NDK_HOME=$android_ndk_home" >> "$GITHUB_OUTPUT"
+      env:
+        INPUT_ANDROID_NDK_HOME: ${{ inputs.android_ndk_home }}
+      shell: bash
+
     - run: ${GITHUB_ACTION_PATH//\\//}/build_and_release.sh
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
@@ -86,9 +105,12 @@ runs:
         GH_RELEASE_TAG: ${{ steps.determine_release_tag.outputs.TAG }}
         GH_RELEASE_TITLE_PREFIX: ${{ steps.determine_release_title_prefix.outputs.PREFIX }}
         DRAFT_RELEASE: ${{ inputs.draft_release }}
+        ANDROID_NDK_HOME: ${{ steps.determine_android_ndk_home.outputs.ANDROID_NDK_HOME }}
+        ANDROID_SDK_VERSION: ${{ inputs.android_sdk_version }}
+        RELEASE_ANDROID: ${{ inputs.release_android }}
       shell: bash
 
     - if: ${{ inputs.generate_attestations == 'true' }}
       uses: actions/attest-build-provenance@v1
       with:
-        subject-path: '${{ github.workspace }}/dist/*'
+        subject-path: "${{ github.workspace }}/dist/*"

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -45,6 +45,16 @@ else
     if [ "$goos" = "windows" ]; then
       ext=".exe"
     fi
+    cc=""
+    if [ "$goos" = "android" ]; then
+      if [ "$goarch" = "amd64" ]; then
+        cc=${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android30-clang
+      elif [ "$goarch" = "arm64" ]; then
+        cc=${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang
+      fi
+      GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=1 CC="$cc" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}"
+      continue
+    fi
     GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="${CGO_ENABLED:-0}" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}"
   done
 fi

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -21,6 +21,12 @@ if [[ "$RELEASE_ANDROID" == "true" ]]; then
   platforms+=("android-arm64")
 fi
 
+# We must know the android sdk version to build for android.
+if [[ "$RELEASE_ANDROID" == "true" && -z "$ANDROID_SDK_VERSION" ]]; then
+  echo "error: Cannot build for android without android_sdk_version." >&2
+  exit 1
+fi
+
 prerelease=""
 if [[ $GH_RELEASE_TAG = *-* ]]; then
   prerelease="--prerelease"

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -2,8 +2,6 @@
 set -e
 
 platforms=(
-  android-amd64
-  android-arm64
   darwin-amd64
   darwin-arm64
   freebsd-386
@@ -17,6 +15,11 @@ platforms=(
   windows-amd64
   windows-arm64
 )
+
+if [[ "$RELEASE_ANDROID" == "true" ]]; then
+  platforms+=("android-amd64")
+  platforms+=("android-arm64")
+fi
 
 prerelease=""
 if [[ $GH_RELEASE_TAG = *-* ]]; then
@@ -46,16 +49,17 @@ else
       ext=".exe"
     fi
     cc=""
+    cgo_enabled="${CGO_ENABLED:-0}"
     if [ "$goos" = "android" ]; then
       if [ "$goarch" = "amd64" ]; then
-        cc=${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android30-clang
+        cc="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android${ANDROID_SDK_VERSION}-clang"
+        cgo_enabled="1"
       elif [ "$goarch" = "arm64" ]; then
-        cc=${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang
+        cc="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android${ANDROID_SDK_VERSION}-clang"
+        cgo_enabled="1"
       fi
-      GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=1 CC="$cc" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}"
-      continue
     fi
-    GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="${CGO_ENABLED:-0}" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}"
+    GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="$cgo_enabled" CC="$cc" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}"
   done
 fi
 

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -27,6 +27,13 @@ if [[ "$RELEASE_ANDROID" == "true" && -z "$ANDROID_SDK_VERSION" ]]; then
   exit 1
 fi
 
+# We must have `ANDROID_NDK_HOME` set to build for android.
+# This will be available by default on GitHub hosted runners.
+if [[ "$RELEASE_ANDROID" == "true" && ! -d "$ANDROID_NDK_HOME" ]]; then
+  echo "error: Cannot build for android without android_ndk_home." >&2
+  exit 1
+fi
+
 prerelease=""
 if [[ $GH_RELEASE_TAG = *-* ]]; then
   prerelease="--prerelease"


### PR DESCRIPTION
Fixes #50

This PR proposes: 

- Extension authors will opt-in to releasing to Android / releasing to Android will be optional in future `gh-extension-precompile` versions.
- Support for building and releasing to Android targets will be best effort but cannot block the release to platforms officially supported by `gh` core. 
- Extensions using Go < 1.22 and wish to release to Android can continue to leverage older versions of `gh-extension-precompile` to avoid this new logic.
- New action inputs:
    - `release_android`
    - `android_sdk_version`
    - `android_ndk_home` 
- These changes will prompt a version bump to `gh-extension-precompile`. 

## Building on Android and change details

We will set `CGO_ENABLED=1` and `CC=${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android${ANDROID_SDK_VERSION}-clang` for Android architectures, if both `release_android` and `android_sdk_version` action inputs are provided. If `release_android` is enabled but `android_sdk_version` is not set, the action will fail.

The `android_ndk_home` action input is used if the  `ANDROID_NDK_HOME` environment variable is not set. [The `$ANDROID_NDK_HOME` environment variable will be set automatically on GitHub hosted runners](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md#environment-variables-2). 

When `release_android` is not set, the action will not attempt to build for Android targets, avoiding the Android specific requirements completely - this is the proposed default behavior. 

## I just want my extension to continue building for Android - what should I do?

Along with bumping the action version, modify your workflow that calls `gh-extension-precompile` to include at least `release_android` and `android_sdk_version`. 

**Example:**

```yaml
- uses: cli/gh-extension-precompile@v2
  with:
    release_android: true
    android_sdk_version: 30
    generate_attestations: true
    go_version_file: go.mod
```

If you are running the workflow on a self-hosted runner, you should confirm that either the `ANDROID_NDK_HOME` environment variable is set or that you provide the `android_ndk_home` action input.

## Testing

### Build and release no android Go@1.22
- [workflow run](https://github.com/bagtoad-enterprise-cloud-testing/gh-bagtoad-test-extension/actions/runs/10690332439/job/29634451791)
- [release & artifacts](https://github.com/bagtoad-enterprise-cloud-testing/gh-bagtoad-test-extension/releases/tag/v0.0.2)

### Build and release with android Go@1.22

- [workflow run](https://github.com/bagtoad-enterprise-cloud-testing/gh-bagtoad-test-extension/actions/runs/10690392114/job/29634654904)
- [release & artifacts](https://github.com/bagtoad-enterprise-cloud-testing/gh-bagtoad-test-extension/releases/tag/v0.0.3)




