### PR TITLE
Add custom Go build options input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,22 +44,6 @@ To maximize portability of built products, this action builds Go binaries with [
     CGO_ENABLED: 1
 ```
 
-### Customizing go build options
-
-You can pass additional options to the `go build` command using the `go_build_options` input parameter. This is useful for specifying a different source directory or adding build tags:
-
-```yaml
-- uses: cli/gh-extension-precompile@v2
-  with:
-    go_build_options: './cmd/my-extension'
-```
-
-```yaml
-- uses: cli/gh-extension-precompile@v2
-  with:
-    go_build_options: '-tags production'
-```
-
 ### Building for Android
 
 `gh-extension-precompile@v2` introduces a breaking change by disabling `android-arm64` and `android-amd64` build targets by default due to [Go external linking requirements](https://github.com/cli/gh-extension-precompile/issues/50#issuecomment-2078086299).
@@ -76,7 +60,21 @@ To enable Android build targets:
 
 ### Customizing the build process for Go extensions
 
-If you need to customize the build process for your Go extension, you can provide a custom build script. See [Extensions written in other compiled languages](#extensions-written-in-other-compiled-languages) below for instructions.
+If you only need to customize the `go build` command, the `go_build_options` input parameter can include additional flags and arguments for all platforms:
+
+```yaml
+- uses: cli/gh-extension-precompile@v2
+  with:
+    go_build_options: './cmd/my-extension'
+```
+
+```yaml
+- uses: cli/gh-extension-precompile@v2
+  with:
+    go_build_options: '-tags production'
+```
+
+For more complex customizations, see [Extensions written in other compiled languages](#extensions-written-in-other-compiled-languages) to provide a custom build script.
 
 ## Extensions written in other compiled languages
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ To maximize portability of built products, this action builds Go binaries with [
     CGO_ENABLED: 1
 ```
 
+### Customizing go build options
+
+You can pass additional options to the `go build` command using the `go_build_options` input parameter. This is useful for specifying a different source directory or adding build tags:
+
+```yaml
+- uses: cli/gh-extension-precompile@v2
+  with:
+    go_build_options: './cmd/my-extension'
+```
+
+```yaml
+- uses: cli/gh-extension-precompile@v2
+  with:
+    go_build_options: '-tags production'
+```
+
 ### Building for Android
 
 `gh-extension-precompile@v2` introduces a breaking change by disabling `android-arm64` and `android-amd64` build targets by default due to [Go external linking requirements](https://github.com/cli/gh-extension-precompile/issues/50#issuecomment-2078086299).

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,8 @@ inputs:
     description: "Path to the Android NDK for android-amd64 and android-arm64 builds"
   android_sdk_version:
     description: "Android SDK build-tools version"
+  go_build_options:
+    description: "Additional options to pass to go build command (e.g., './cmd/my-extension' to specify source directory or '-tags production' for build tags)"
 branding:
   color: purple
   icon: box
@@ -108,6 +110,7 @@ runs:
         ANDROID_NDK_HOME: ${{ steps.determine_android_ndk_home.outputs.ANDROID_NDK_HOME }}
         ANDROID_SDK_VERSION: ${{ inputs.android_sdk_version }}
         RELEASE_ANDROID: ${{ inputs.release_android }}
+        GO_BUILD_OPTIONS: ${{ inputs.go_build_options }}
       shell: bash
 
     - if: ${{ inputs.generate_attestations == 'true' }}

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -72,7 +72,7 @@ else
         cgo_enabled="1"
       fi
     fi
-    GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="$cgo_enabled" CC="$cc" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}"
+    GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="$cgo_enabled" CC="$cc" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}" ${GO_BUILD_OPTIONS}
   done
 fi
 


### PR DESCRIPTION
This pull request introduces the ability to customize `go build` options in the `gh-extension-precompile` GitHub Action. The most important changes include adding a new input parameter for `go_build_options`, updating the build script to use this parameter, and documenting its usage in the `README.md`.

This enhancement is needed when Go source files are not located in the root of the repository or when additional build flags are required.