### PR TITLE
[nitpick] Update crazy-max/ghaction-import-gpg to v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
Node 20 is used as default runtime in v6 and later.
https://github.com/crazy-max/ghaction-import-gpg/releases/tag/v6.0.0