### PR TITLE
Fix: `GO_BUILD_ARGS` is now properly double-quoted

### DIFF
--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -72,7 +72,7 @@ else
         cgo_enabled="1"
       fi
     fi
-    GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="$cgo_enabled" CC="$cc" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}" ${GO_BUILD_OPTIONS}
+    GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="$cgo_enabled" CC="$cc" go build -trimpath -ldflags="-s -w" -o "dist/${p}${ext}" "${GO_BUILD_OPTIONS}"
   done
 fi
 


### PR DESCRIPTION
Fixes #70 

(Also as an irrelevant side note: the error logs could probably use some logs and/or consistent capitalization. That can arguably be another PR)