### PR TITLE
chore: upgrade attest-build-provenance to v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -114,6 +114,6 @@ runs:
       shell: bash
 
     - if: ${{ inputs.generate_attestations == 'true' }}
-      uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
         subject-path: "${{ github.workspace }}/dist/*"


### PR DESCRIPTION
This updates attest-build-provenance to v3 to pull the latest improvements on actions/attest and Node.js runtime update (it may require a major update).

Closes #69