### PR TITLE
chore: bump setup-go to v6

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
   using: composite
   steps:
     # TODO: figure out how to avoid setting up Go for non-Go extensions
-    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+    - uses: actions/setup-go@v6 # v5.5.0
       with:
         # The default go version is managed here because actions/setup-go favors go-version over go-version-file,
         # requiring us to only pass it if no other inputs are provided.


### PR DESCRIPTION
Current version used 403's when trying to download Go