### PR TITLE
Add dependabot config for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  cooldown:
+    default-days: 5


### PR DESCRIPTION
Adds a Dependabot configuration to keep GitHub Actions dependencies up to date daily, with a 5-day cooldown. Mirrors the github-actions section of cli/oauth's config (gomod omitted since this repo has no Go module).