### PR TITLE
Add CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: Code Scanning
+
+on:
+  push:
+    branches: [trunk]
+  pull_request:
+    branches: [trunk]
+    paths-ignore:
+      - '**/*.md'
+  schedule:
+    - cron: "0 0 * * 0"
+
+permissions:
+  actions: read  # for github/codeql-action/init to get workflow details
+  contents: read  # for actions/checkout to fetch code
+  security-events: write  # for github/codeql-action/analyze to upload SARIF results
+
+jobs:
+  CodeQL-Build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: actions
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:actions"


### PR DESCRIPTION
Adds a CodeQL code scanning workflow for the GitHub Actions defined in this repository.

- Scans `actions` only — no Go source lives here (the repo is composed of `action.yml` and shell scripts, which CodeQL does not analyse).
- Uses `security-and-quality` queries.
- Runs on push/PR to `trunk` (docs-only PR changes skipped) and weekly on Sunday.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>